### PR TITLE
remove has_rdoc from gemspec since the method is deprecated

### DIFF
--- a/axlsx.gemspec
+++ b/axlsx.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.date        = Time.now.strftime('%Y-%m-%d')
   s.summary     = "Excel OOXML (xlsx) with charts, styles, images and autowidth columns."
-  s.has_rdoc    = 'axlsx'
   s.license     = 'MIT'
   s.description = <<-eof
     xlsx spreadsheet generation with charts, images, automated column width, customizable styles and full schema validation. Axlsx helps you create beautiful Office Open XML Spreadsheet documents ( Excel, Google Spreadsheets, Numbers, LibreOffice) without having to understand the entire ECMA specification. Check out the README for some examples of how easy it is. Best of all, you can validate your xlsx file before serialization so you know for sure that anything generated is going to load on your client's machine.


### PR DESCRIPTION
this PR fixes a deprecation raised by Rubygems 1.7.0, also there is a PR for the main axlsx gem that handles this same issue:
https://github.com/randym/axlsx/pull/593

Once this is pulled in, we should look at updating the Gemfile to use the main version, since @wpeterson's previous issue fix was also merged for the next release.