### PR TITLE
Fix CWE-78 in package.rb: use File.binread/File.read instead of IO.binread/IO.read

### DIFF
--- a/lib/axlsx/package.rb
+++ b/lib/axlsx/package.rb
@@ -178,7 +178,7 @@ module Axlsx
         unless part[:path].nil?
           zip.put_next_entry(zip_entry_for_part(part))
           # binread for 1.9.3
-          zip.write IO.respond_to?(:binread) ? IO.binread(part[:path]) : IO.read(part[:path])
+          zip.write IO.respond_to?(:binread) ? File.binread(part[:path]) : File.read(part[:path])
         end
       end
       zip


### PR DESCRIPTION
## Summary

- Resolves the two critical GitHub code scanning alerts on `master` ([alert #1](https://github.com/ezcater/axlsx/security/code-scanning/1), [alert #2](https://github.com/ezcater/axlsx/security/code-scanning/2)) — `rb/non-constant-kernel-open` at `lib/axlsx/package.rb:181`.
- `IO.binread` / `IO.read` are aliases of `Kernel.open` and execute the value as a shell command when it begins with `|`. Switching to `File.binread` / `File.read` removes that surface.
- Mirrors the substitution adopted by the actively-maintained successor gem [`caxlsx`](https://github.com/caxlsx/caxlsx/blob/master/lib/axlsx/package.rb#L219).

## Context

This is the surgical patch chosen in the [MX-1374 investigation](https://ezcater.atlassian.net/wiki/spaces/POL/pages/6311247893). ez-rails is not actually exposed to the vulnerability today — the affected branch in `Package#write_parts` is only entered when `part[:path]` is set, which only happens for `workbook.images`, and ez-rails has zero callers of `add_image`. This patch exists to clear the CodeQL alert on the canonical `master` branch.

The fork is in a terminal state (no functional commits since 2017). The longer-term plan is to sunset this fork once ez-rails migrates off it; tracked separately.

Ticket: [MX-1384](https://ezcater.atlassian.net/browse/MX-1384)

## Test plan

- [ ] CodeQL re-scan on this branch clears alerts #1 and #2.
- [ ] No functional tests exist for the image-path branch in this gem; the change matches the caxlsx upstream substitution verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MX-1384]: https://ezcater.atlassian.net/browse/MX-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ