### PR TITLE
Mark repository as archived in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This repository is archived.** ezCater has migrated to the maintained [caxlsx](https://github.com/caxlsx/caxlsx) gem. This fork is no longer used or updated.
+
 Axlsx: Office Open XML Spreadsheet Generation
 ====================================
 [![Build Status](https://secure.travis-ci.org/randym/axlsx.svg?branch=master)](http://travis-ci.org/randym/axlsx/)


### PR DESCRIPTION
## Summary
Adds an archive notice to the top of the README directing readers to the maintained [caxlsx](https://github.com/caxlsx/caxlsx) gem.

Per [MX-1384](https://ezcater.atlassian.net/browse/MX-1384), ez-rails migrated from `ezcater/axlsx` to `caxlsx` in [ezcater/ez-rails#42373](https://github.com/ezcater/ez-rails/pull/42373), and an org-wide code search confirmed no other consumers. This is the final step before flipping the GitHub archive flag on the repo.

## Test plan
- [ ] README renders correctly on GitHub

[MX-1384]: https://ezcater.atlassian.net/browse/MX-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ